### PR TITLE
Make proxy method names more unique to prevent collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
         }
     },
     "require": {
+        "php": "^7.2",
         "ocramius/proxy-manager": "^2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^8.0"
     },
     "license": "MIT",
     "authors": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
 		convertWarningsToExceptions = "true"
 		processIsolation            = "false"
 		stopOnFailure               = "false"
-		bootstrap                   = "test/bootstrap.php"
+		bootstrap                   = "vendor/autoload.php"
 	>
 
 	<testsuites>

--- a/src/MockableService/MockableService.php
+++ b/src/MockableService/MockableService.php
@@ -12,17 +12,17 @@ interface MockableService
     /**
      * Use the given mock/fake/etc 'alternative' implementation, instead of the 'original' service.
      */
-    public function setAlternative(object $alternative): void;
+    public function setAlternativeService(object $alternative): void;
 
     /**
      * Use this service as 'original' service.
      *
      * Note: this method is only intended to be called once, at start (i.e. in a service container).
      */
-    public function setOriginal(object $original): void;
+    public function setOriginalService(object $original): void;
 
     /**
      * Remove the 'alternative' service and revert to 'original' service.
      */
-    public function reset(): void;
+    public function restoreOriginalServices(): void;
 }

--- a/src/MockableService/MockableServiceProxyFactory.php
+++ b/src/MockableService/MockableServiceProxyFactory.php
@@ -16,16 +16,16 @@ class MockableServiceProxyFactory extends LazyLoadingValueHolderFactory
     /**
      * Create a service-proxy based on the given original.
      *
-     * @param object $original The service to proxy and use ad original.
+     * @param object $original The service to proxy and use as original.
      *
      * @return MockableService
      */
-    public function createServiceProxy(object $original)
+    public function createServiceProxy(object $original): MockableService
     {
         /** @var MockableService $proxy */
-        $proxy = $this->createProxy(get_class($original), function () use ($original) {return $original; }, []);
+        $proxy = $this->createProxy(get_class($original), function () use ($original) {return $original; });
 
-        $proxy->setOriginal($original);
+        $proxy->setOriginalService($original);
 
         return $proxy;
     }

--- a/src/MockableService/MockableServiceProxyGenerator.php
+++ b/src/MockableService/MockableServiceProxyGenerator.php
@@ -15,7 +15,7 @@ use Zend\Code\Generator\PropertyGenerator;
  * The intended use is in conjunction with services that need to be 'mocked' (or otherwise replaced by a test double) during testing.
  *
  * It generates a proxy that 'forwards' all calls to the original implementation by default,
- * but allows to set an alternative implementation (i.e. a mock, fake, etc). When a test is done, the proxy can be 'reset' to the original service.
+ * but allows to set an alternative implementation (i.e. a mock, fake, etc). When a test is done, the proxy can be 'restored' to the original service.
  *
  * @note The only reason it extends the LazyLoading-proxy is simply because that already did most of the necessary work.
  *
@@ -24,9 +24,9 @@ use Zend\Code\Generator\PropertyGenerator;
  * In addition to that property, it adds an 'originalService'-property to keep track of the 'default' service
  *
  * It also adds these methods to allow modifying the state:
- * 'setOriginal' @see SetOriginalGenerator
- * 'setAlternative' @see SetAlternativeGenerator
- * 'reset' @see ResetGenerator
+ * 'setOriginalService' @see SetOriginalGenerator
+ * 'setAlternativeService' @see SetAlternativeGenerator
+ * 'restoreOriginalServices' @see RestoreOriginalsGenerator
  *
  * @author Arjen
  */
@@ -46,7 +46,7 @@ class MockableServiceProxyGenerator extends LazyLoadingValueHolderGenerator
 
         $classGenerator->addPropertyFromGenerator($original);
 
-        ClassGeneratorUtils::addMethodIfNotFinal($originalClass, $classGenerator, new ResetGenerator($original, $valueHolder));
+        ClassGeneratorUtils::addMethodIfNotFinal($originalClass, $classGenerator, new RestoreOriginalsGenerator($original, $valueHolder));
         ClassGeneratorUtils::addMethodIfNotFinal($originalClass, $classGenerator, new SetAlternativeGenerator($valueHolder));
         ClassGeneratorUtils::addMethodIfNotFinal($originalClass, $classGenerator, new SetOriginalGenerator($original, $valueHolder));
     }

--- a/src/MockableService/RestoreOriginalsGenerator.php
+++ b/src/MockableService/RestoreOriginalsGenerator.php
@@ -6,11 +6,11 @@ use ProxyManager\Generator\MethodGenerator;
 use Zend\Code\Generator\PropertyGenerator;
 
 /**
- * Generator for a reset-method that restores the original service as 'the service to use' within the proxy.
+ * Generator for a restore-method that restores the original service as 'the service to use' within the proxy.
  *
  * It generates this method:
  *
- * public function setOriginal(object $original) : void
+ * public function restoreOriginalServices(object $original) : void
  * {
  *   $this->originalService = $original;
  *   $this->valueHolder = $original;
@@ -18,11 +18,11 @@ use Zend\Code\Generator\PropertyGenerator;
  *
  * @author Arjen van der Meijden <acm@tweakers.net>
  */
-class ResetGenerator extends MethodGenerator
+class RestoreOriginalsGenerator extends MethodGenerator
 {
     public function __construct(PropertyGenerator $original, PropertyGenerator $valueHolder)
     {
-        parent::__construct('reset');
+        parent::__construct('restoreOriginalServices');
 
         $this->setDocBlock('{@inheritDoc}');
         $this->setReturnType('void');

--- a/src/MockableService/SetAlternativeGenerator.php
+++ b/src/MockableService/SetAlternativeGenerator.php
@@ -11,7 +11,7 @@ use Zend\Code\Generator\PropertyGenerator;
  *
  * It generates this method:
  *
- * public function setAlternative(object $alternative) : void
+ * public function setAlternativeService(object $alternative) : void
  * {
  *   $this->valueHolder = $alternative;
  * }
@@ -22,7 +22,7 @@ class SetAlternativeGenerator extends MethodGenerator
 {
     public function __construct(PropertyGenerator $valueHolder)
     {
-        parent::__construct('setAlternative');
+        parent::__construct('setAlternativeService');
 
         $alternativeParameter = new ParameterGenerator('alternative');
         $alternativeParameter->setType('object');

--- a/src/MockableService/SetOriginalGenerator.php
+++ b/src/MockableService/SetOriginalGenerator.php
@@ -9,11 +9,11 @@ use Zend\Code\Generator\PropertyGenerator;
 /**
  * Generator for a setOriginal-method that sets the 'base' service which is used by default within the proxy.
  *
- * It stores both a reference for a later reset-call as the value that is used.
+ * It stores both a reference for a later restore-call as the value that is used.
  *
  * It generates this method:
  *
- * public function setOriginal(object $original) : void
+ * public function setOriginalService(object $original) : void
  * {
  *   $this->originalService = $original;
  *   $this->valueHolder = $original;
@@ -25,7 +25,7 @@ class SetOriginalGenerator extends MethodGenerator
 {
     public function __construct(PropertyGenerator $original, PropertyGenerator $valueHolder)
     {
-        parent::__construct('setOriginal');
+        parent::__construct('setOriginalService');
 
         $originalParameter = new ParameterGenerator('original');
         $originalParameter->setType('object');

--- a/test/MockableService/MockableServiceProxyFactoryTest.php
+++ b/test/MockableService/MockableServiceProxyFactoryTest.php
@@ -19,7 +19,7 @@ class MockableServiceProxyFactoryTest extends TestCase
     /** @var MockableService|FakeService $proxy */
     private $proxy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -32,7 +32,7 @@ class MockableServiceProxyFactoryTest extends TestCase
     }
 
     /** @test */
-    public function it_should_generate_a_mockable_service_proxy()
+    public function it_should_generate_a_mockable_service_proxy(): void
     {
         $this->assertInstanceOf(MockableService::class, $this->proxy);
         $this->assertInstanceOf(FakeService::class, $this->proxy);
@@ -41,17 +41,17 @@ class MockableServiceProxyFactoryTest extends TestCase
     }
 
     /** @test */
-    public function it_should_generate_a_working_set_alternative()
+    public function it_should_generate_a_working_set_alternative(): void
     {
-        $this->proxy->setAlternative($this->alternative);
+        $this->proxy->setAlternativeService($this->alternative);
         $this->assertEquals($this->alternative->getValue(), $this->proxy->getValue());
     }
 
     /** @test */
-    public function it_should_generate_a_working_reset()
+    public function it_should_generate_a_working_reset(): void
     {
-        $this->proxy->setAlternative($this->alternative);
-        $this->proxy->reset();
+        $this->proxy->setAlternativeService($this->alternative);
+        $this->proxy->restoreOriginalServices();
 
         $this->assertEquals($this->original->getValue(), $this->proxy->getValue());
     }

--- a/test/MockableService/OriginalPropertyPropertyGeneratorTest.php
+++ b/test/MockableService/OriginalPropertyPropertyGeneratorTest.php
@@ -5,10 +5,10 @@ namespace Tweakers\Test\MockableService;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\PropertyGenerator;
 
-class SetOriginalGeneratorTest extends TestCase
+class OriginalPropertyGeneratorTest extends TestCase
 {
     /** @test */
-    public function it_should_generate_a_set_method()
+    public function it_should_generate_a_set_method(): void
     {
         $original    = new PropertyGenerator('original');
         $valueHolder = new PropertyGenerator('valueHolder');
@@ -21,7 +21,7 @@ class SetOriginalGeneratorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setOriginal(object $original) : void
+    public function setOriginalService(object $original) : void
     {
         $this->original = $original;
         $this->valueHolder = $original;

--- a/test/MockableService/RestoreOriginalsGeneratorTest.php
+++ b/test/MockableService/RestoreOriginalsGeneratorTest.php
@@ -5,15 +5,15 @@ namespace Tweakers\Test\MockableService;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\PropertyGenerator;
 
-class ResetGeneratorTest extends TestCase
+class RestoreOriginalsGeneratorTest extends TestCase
 {
     /** @test */
-    public function it_should_generate_the_reset_method()
+    public function it_should_generate_the_reset_method(): void
     {
         $original    = new PropertyGenerator('original');
         $valueHolder = new PropertyGenerator('valueHolder');
 
-        $generator = new ResetGenerator($original, $valueHolder);
+        $generator = new RestoreOriginalsGenerator($original, $valueHolder);
 
         $output = $generator->generate();
 
@@ -21,7 +21,7 @@ class ResetGeneratorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function reset() : void
+    public function restoreOriginalServices() : void
     {
         $this->valueHolder = $this->original;
     }

--- a/test/MockableService/SetAlternativeGeneratorTest.php
+++ b/test/MockableService/SetAlternativeGeneratorTest.php
@@ -8,7 +8,7 @@ use Zend\Code\Generator\PropertyGenerator;
 class SetAlternativeGeneratorTest extends TestCase
 {
     /** @test */
-    public function it_should_generate_a_set_method()
+    public function it_should_generate_a_set_method(): void
     {
         $valueHolder = new PropertyGenerator('valueHolder');
 
@@ -20,7 +20,7 @@ class SetAlternativeGeneratorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setAlternative(object $alternative) : void
+    public function setAlternativeService(object $alternative) : void
     {
         $this->valueHolder = $alternative;
     }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Currently the `reset` method collided with a service that already had that method